### PR TITLE
Remove overflow-y in lehrgangsanmeldung

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -45,7 +45,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       this.elementRef.nativeElement.appendChild(lgscript);
 
       let lglist = document.createElement('x-lehrgangsanmeldung');
-      lglist.style.cssText='font-size: .8em; overflow-y: auto;'
+      lglist.style.cssText='font-size: .8em;'
       this.lghost.nativeElement.appendChild(lglist)
   }
 


### PR DESCRIPTION
The overflow is already included in the layout with a fixed header. So specifying it on the outer tag is not needed anymore. It could even lead to an additional scrollbar.