### PR TITLE
chore: add .angular/cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 /dist
 /tmp
 /out-tsc
+
+# Angular cache
+/.angular/cache
+
 # Only exists if Bazel was run
 /bazel-out
 


### PR DESCRIPTION
- Add .angular/cache to .gitignore to prevent Angular cache files from being tracked in git
- This helps keep the repository clean and prevents unnecessary files from being committed